### PR TITLE
Show total costs for all stages

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -38,7 +38,10 @@
         </div>
         <div class="row">
             <div class="well">
-                Approximate total monthly cost for all stages: $@money.format(estate(stage).map(_.approxMonthlyCost).sum)
+                Approximate total monthly cost for all ASGs: $@money.format(estate(stage).map(_.approxMonthlyCost).sum)
+                @if(estate.size > 1) {
+                  (for all stages: $@money.format(estate.values.flatMap(_.map(_.approxMonthlyCost)).sum))
+                }
                 @if(totalSunkCost > 0) { (total sunk cost: $@money.format(totalSunkCost)) }
             </div>
         </div>


### PR DESCRIPTION
The message about estimated costs says, "Approximate total monthly cost for all stages", but in fact it is only for the currently selected stage, so I think really it means "for all ASGs [in this stage]".

This patch fixes the wording, and also shows the real total cost across all stages.
