### PR TITLE
Add sub-navigation by stack

### DIFF
--- a/app/assets/css/main.less
+++ b/app/assets/css/main.less
@@ -85,3 +85,7 @@ table {
 .asg {
   overflow: hidden;
 }
+
+.stacks {
+  margin: 5px 0;
+}

--- a/app/lib/AmazonConnection.scala
+++ b/app/lib/AmazonConnection.scala
@@ -13,6 +13,9 @@ import scala.util.{Success, Failure}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
 import com.amazonaws.regions.{Regions, Region}
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import play.api.libs.json.{Json, Writes}
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import model.ScalingAction
 
 class AmazonConnection(credentials: Option[AWSCredentials], clientConfig: ClientConfiguration) {
   val credentialsProvider =  new AWSCredentialsProvider() {
@@ -51,5 +54,20 @@ object AWS {
 
   lazy val connection = new AmazonConnection(Config.credentials, Config.clientConfiguration)
 
+  object Writes {
+    implicit val datapointWrites = new Writes[Datapoint] {
+      override def writes(d: Datapoint) = Json.obj(
+        "time" -> d.getTimestamp.getTime,
+        "average" -> Option(d.getAverage).map(_.toInt),
+        "maximum" -> Option(d.getMaximum).map(_.toInt)
+      )
+    }
 
+    implicit val scalingActionWrites = new Writes[ScalingAction] {
+      override def writes(a: ScalingAction) = Json.obj(
+        "age" -> a.age,
+        "cause" -> a.cause
+      )
+    }
+  }
 }

--- a/app/model/ASG.scala
+++ b/app/model/ASG.scala
@@ -17,70 +17,29 @@ import com.amazonaws.services.cloudwatch.model.Statistic._
 import org.joda.time.DateTime
 import play.api.libs.json.JsObject
 
-case class WebAppASG(asg: AutoScalingGroup, elb: Option[ELB], recentActivity: Seq[ScalingAction],
-                     members: Seq[ClusterMember], cpu: Seq[Datapoint])
-  extends ASG
-
-trait ASG {
-  val asg: AutoScalingGroup
-  val elb: Option[ELB]
-  val recentActivity: Seq[ScalingAction]
-  val members: Seq[ClusterMember]
-  val cpu: Seq[Datapoint]
-
-  lazy val name = asg.getAutoScalingGroupName
-  lazy val tags = asg.getTags.map(t => t.getKey -> t.getValue).toMap
-
-  lazy val stage = tags.get("Stage").getOrElse("?")
-  lazy val appName = (tags get "Role") orElse (tags get "App") getOrElse "?"
-
-  lazy val hasElb = elb.isDefined
-
-  lazy val suspendedActivities = asg.getSuspendedProcesses.toList.map(_.getProcessName).sorted
-
-  lazy val approxMonthlyCost =
-    Try(members.map(_.instance.approxMonthlyCost).sum).getOrElse(BigDecimal(0))
-
-  def moreDetailsLink: Option[String] = ManagementTag(tags.get("Management")).flatMap { t =>
-    if (t.format == Some("elasticsearch")) Some(routes.Application.es(name).url) else None
-  }
-}
-
-case class ClusterMember(asgInfo: AwsAsgInstance, elbInfo: Option[ELB#Member], instance: Instance) {
-  def id = asgInfo.getInstanceId
-  def healthStatus = asgInfo.getHealthStatus
-  def lifecycleState = asgInfo.getLifecycleState
-
-  def state = elbInfo.map(_.state)
-  def description = elbInfo.flatMap(_.description)
-  def reasonCode = elbInfo.flatMap(_.reasonCode)
-
-  def goodorbad = (healthStatus, lifecycleState, state) match {
-    case (_, "Pending", _) | (_, "Terminating", _) => "pending"
-    case ("Healthy", "InService", Some("InService")) => "success"
-    case ("Healthy", "InService", None) => "success"
-    case _ => "danger"
-  }
-}
+case class ASG(name: String, stage: Option[String], app: Option[String], stack: Option[String],
+                 elb: Option[ELB], members: Seq[ASGMember], recentActivity: Seq[ScalingAction],
+                 cpu: Seq[Datapoint],suspendedActivities: Seq[String], approxMonthlyCost: Option[BigDecimal],
+                 moreDetailsLink: Option[String])
 
 object ASG {
   val log = Logger[ASG](classOf[ASG])
 
-  def apply(asg: AutoScalingGroup)(implicit conn: AmazonConnection): Future[ASG] =  {
-    log.info(s"Retrieving details for ${asg.getAutoScalingGroupName}")
-    val instanceStates = Future.sequence((asg.getLoadBalancerNames.headOption map (ELB(_))).toSeq)
+  def from(asg: AutoScalingGroup)(implicit conn: AmazonConnection): Future[ASG] =  {
+    log.debug(s"Retrieving details for ${asg.getAutoScalingGroupName}")
+    val elb = FutureOption((asg.getLoadBalancerNames.headOption map (ELB.forName(_))))
 
     val recentActivity = for {
       actions <- ScalingAction.forGroup(asg.getAutoScalingGroupName)
     } yield actions filter (_.isRecent)
 
     val clusterMembers = for {
-      elb <- instanceStates
+      lb <- elb
       members <- Future.sequence(asg.getInstances map { m =>
-        val membersOfElb = elb.headOption.map(_.members).getOrElse(Nil)
+        val membersOfElb = lb.map(_.members).getOrElse(Nil)
         for {
           i <- Instance.get(m.getInstanceId)
-        } yield new ClusterMember(m, membersOfElb.find(_.id == m.getInstanceId), i)
+        } yield ASGMember.from(m, membersOfElb.find(_.id == m.getInstanceId), i)
       })
     } yield members
 
@@ -92,65 +51,28 @@ object ASG {
     )
 
     for {
-      states <- instanceStates
+      lb <- elb
       activities <- recentActivity
       members <- clusterMembers
       asgStats <- stats
     } yield {
-      val maxCPU = asgStats.getDatapoints.sortBy(_.getTimestamp)
-      WebAppASG(asg, states.headOption, activities, members, maxCPU)
+      val cpu = asgStats.getDatapoints.sortBy(_.getTimestamp)
+      val tags = asg.getTags.map(t => t.getKey -> t.getValue).toMap
+      val name = asg.getAutoScalingGroupName
+      val moreDetailsLink = ManagementTag(tags.get("Management")).flatMap { t =>
+        if (t.format == Some("elasticsearch")) Some(routes.Application.es(name).url) else None
+      }
+      ASG(
+        name, tags.get("Stage"), tags.get("App") orElse tags.get("Role"), tags.get("Stack"),
+        lb, members, activities, cpu, asg.getSuspendedProcesses.toList.map(_.getProcessName).sorted,
+        Try(members.flatMap(_.instance.approxMonthlyCost).sum).toOption, moreDetailsLink
+      )
     }
   }
 
-  implicit val datapointWrites = new Writes[Datapoint]{
-    override def writes(d: Datapoint) = Json.obj(
-      "time" -> d.getTimestamp.getTime,
-      "average" -> Option(d.getAverage).map(_.toInt),
-      "maximum" -> Option(d.getMaximum).map(_.toInt)
-    )
-  }
+  import AWS.Writes._
 
-  implicit val memberWrites = new Writes[ClusterMember] {
-    def writes(m: ClusterMember) = Json.obj(
-      "id" -> m.id,
-      "goodorbad" -> m.goodorbad,
-      "lifecycleState" -> m.lifecycleState,
-      "state" -> m.state,
-      "description" -> m.description,
-      "uptime" -> m.instance.uptime,
-      "version" -> JsString(m.instance.version.getOrElse("?")),
-      "url" -> routes.Application.instance(m.id).url
-    )
-  }
-
-  implicit val scalingActionWrites = new Writes[ScalingAction] {
-    override def writes(a: ScalingAction) = Json.obj(
-      "age" -> a.age,
-      "cause" -> a.cause
-    )
-  }
-
-  implicit val elbWrites = new Writes[ELB] {
-    override def writes(elb: ELB) = Json.obj(
-      "name" -> elb.name,
-      "latency" -> elb.latency.map(d => new Datapoint().withTimestamp(d.getTimestamp).withAverage(d.getAverage * 1000)),
-      "active" -> elb.active
-    )
-  }
-
-  implicit val writes = new Writes[ASG] {
-    def writes(asg: ASG) = Json.obj(
-      "name" -> asg.name,
-      "appName" -> asg.appName,
-      "members" -> asg.members,
-      "recentActivity" -> asg.recentActivity,
-      "cpu" -> asg.cpu,
-      "elb" -> asg.elb,
-      "approxMonthlyCost" -> asg.approxMonthlyCost,
-      "moreDetailsLink" -> asg.moreDetailsLink,
-      "suspendedActivities" -> asg.suspendedActivities
-    )
-  }
+  implicit val writes = Json.writes[ASG]
 }
 
 object FutureOption {

--- a/app/model/ASGMember.scala
+++ b/app/model/ASGMember.scala
@@ -1,0 +1,30 @@
+package model
+
+import com.amazonaws.services.autoscaling.model.{Instance => AwsAsgInstance, _}
+import play.api.libs.json.Json
+
+case class ASGMember(id: String, description: Option[String], uptime: String, version: Option[String],
+                     state: Option[String], lifecycleState: String, goodorbad: String, instance: Instance)
+
+object ASGMember {
+  implicit val memberWrites = Json.writes[ASGMember]
+
+  def from(asgInfo: AwsAsgInstance, elbInfo: Option[ELBMember], instance: Instance): ASGMember = {
+    def healthStatus = asgInfo.getHealthStatus
+    def lifecycleState = asgInfo.getLifecycleState
+
+    def state = elbInfo.map(_.state)
+    def description = elbInfo.flatMap(_.description)
+
+    def goodorbad = (healthStatus, lifecycleState, state) match {
+      case (_, "Pending", _) | (_, "Terminating", _) => "pending"
+      case ("Healthy", "InService", Some("InService")) => "success"
+      case ("Healthy", "InService", None) => "success"
+      case _ => "danger"
+    }
+    ASGMember(asgInfo.getInstanceId, description, instance.uptime, instance.version,
+      state, lifecycleState, goodorbad, instance)
+  }
+}
+
+

--- a/app/model/AWSCost.scala
+++ b/app/model/AWSCost.scala
@@ -54,7 +54,7 @@ object AWSCost {
     for {
       reservations <- AWS.futureOf(awsConnection.ec2.describeInstancesAsync, new DescribeInstancesRequest())
       instances <- Future.sequence (
-        reservations.getReservations flatMap (_.getInstances) map (Instance(_))
+        reservations.getReservations flatMap (_.getInstances) map (Instance.from(_))
       )
     } yield instances.groupBy(_.costingType).mapValues(_.size)
   }
@@ -139,6 +139,9 @@ case class OnDemandPrices(regions: Map[String, RegionPrices])
 case class RegionPrices(instanceTypes: Map[String, BigDecimal])
 
 case class EC2CostingType(instanceType: String, zone: String)
+object EC2CostingType {
+  implicit val writes = Json.writes[EC2CostingType]
+}
 case class Reservation(count: Int, fixedPrice: Float, hourlyRate: Double) {
   def hourlyCost = count * hourlyRate
   def sunkCost = count * fixedPrice

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -28,7 +28,7 @@
         </div>
 
         <div id="stage" class="row">
-            @for(asg <- estate(stage)) {
+            @for(asg <- estate(stage).asgs) {
                 @snippets.renderASG(asg)
             }
             <script>
@@ -37,9 +37,9 @@
         </div>
         <div class="row">
             <div class="well">
-                Approximate total monthly cost for all ASGs: $@money.format(estate(stage).map(_.approxMonthlyCost).sum)
+                Approximate total monthly cost for all ASGs: $@money.format(estate(stage).asgs.flatMap(_.approxMonthlyCost).sum)
                 @if(estate.size > 1) {
-                  (for all stages: $@money.format(estate.values.flatMap(_.map(_.approxMonthlyCost)).sum))
+                  (for all stages: $@money.format(estate.values.flatMap(_.asgs.flatMap(_.approxMonthlyCost)).sum))
                 }
                 @if(totalSunkCost > 0) { (total sunk cost: $@money.format(totalSunkCost)) }
             </div>

--- a/app/views/snippets/renderASG.scala.html
+++ b/app/views/snippets/renderASG.scala.html
@@ -2,8 +2,8 @@
 <div class="asg panel panel-default">
     <div class="panel-heading">
         <h4 class="panel-title">
-            @for(link <- asg.moreDetailsLink) {<a href="@link">}@asg.appName @for(link <- asg.moreDetailsLink) {</a>}
-            <small>(~ $@money.format(asg.approxMonthlyCost)/month)</small>
+            @asg.app
+            @for(cost <- asg.approxMonthlyCost){<small>(~ $@money.format(cost)/month)</small>}
         </h4>
     </div>
 
@@ -19,7 +19,7 @@
         <thead>
             <th>Instance</th>
             <th>AutoScaling</th>
-            @if(asg.hasElb) {
+            @for(_ <- asg.elb) {
                 <th>ELB</th>
             }
             <th>Uptime</th>
@@ -30,7 +30,7 @@
             <tr class="@member.goodorbad">
                 <td><a href="@routes.Application.instance(member.id)">@member.id</a></td>
                 <td>@member.lifecycleState</td>
-                @if(asg.hasElb) {
+                @for(_ <- asg.elb) {
                     <td title="@member.description">@member.state<br>@member.description</td>
                 }
                 <td>@member.instance.uptime</td>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,7 +24,7 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
-ws.timeout=200
+ws.timeout.connection=500
 
 managementPort=${?MANAGEMENT_PORT}
 accessKey=${?ACCESS_KEY}

--- a/test/model/EstateTest.scala
+++ b/test/model/EstateTest.scala
@@ -4,22 +4,42 @@ import org.specs2.mutable._
 import com.amazonaws.services.autoscaling.model.{TagDescription, AutoScalingGroup}
 import collection.convert.wrapAll._
 import org.joda.time.DateTime
+import scala.util.Random
 
 class EstateTest extends Specification {
   "Estate stages" should {
     "be sorted with PROD first" in {
       val estate = PopulatedEstate(Seq(
-        WebAppASG(new AutoScalingGroup().withTags(Seq(tag("Stage" -> "TEST"))), None, Seq(), Seq(), Seq()),
-        WebAppASG(new AutoScalingGroup().withTags(Seq(tag("Stage" -> "PROD"))), None, Seq(), Seq(), Seq()),
-        WebAppASG(new AutoScalingGroup().withTags(Seq(tag("Stage" -> "CODE"))), None, Seq(), Seq(), Seq()),
-        WebAppASG(new AutoScalingGroup().withTags(Seq(tag("Stage" -> "QA"))), None, Seq(), Seq(), Seq())
+        asg("TEST"),
+        asg("PROD"),
+        asg("CODE"),
+        asg("QA")
       ), Seq(), DateTime.now)
       estate.stageNames should contain(exactly("PROD", "CODE", "QA", "TEST"))
     }
   }
 
-  def tag(keyValue: (String, String)) = {
-    val (key, value) = keyValue
-    new TagDescription().withKey(key).withValue(value)
+  "Should have a list of stages, each with all relevant stacks" in {
+    val estate = PopulatedEstate(Seq(
+      asg("PROD", Some("a")),
+      asg("PROD", Some("a")),
+      asg("PROD", Some("b")),
+      asg("PROD", None)
+    ), Seq(), DateTime.now)
+    estate("PROD").stacks should haveLength(3)
   }
+
+  "Stacks should be in alphabetic order" in {
+    val estate = PopulatedEstate(Seq(
+      asg("PROD", Some("a")),
+      asg("PROD", Some("a")),
+      asg("PROD", Some("b")),
+      asg("PROD", None)
+    ), Seq(), DateTime.now)
+    estate("PROD").stacks.map(_.name).toSeq should be_== (Seq("a", "b", "unknown"))
+  }
+
+  def asg(stage: String, stack: Option[String] = None) = ASG(
+    s"name-${Random.alphanumeric}", Some(stage), None, stack, None, Nil, Nil, Nil, Nil, None, None
+  )
 }


### PR DESCRIPTION
This builds on #18, so it might be worth viewing https://github.com/guardian/status-app/compare/pw-case-classes-for-serialization...stacks?expand=1 if you just want to see the Stack specific work.

@jennysivapalan does this look sensible:

![image](https://cloud.githubusercontent.com/assets/68329/2983180/59d48138-dc1f-11e3-966b-105f93a666ab.png)
