### PR TITLE
Add NotFound page for instances

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -60,7 +60,7 @@ object Application extends Controller with AuthActions {
       asg <- Estate().asgs
       member <- asg.members if member.id == id
     } yield member
-    instance.headOption map (i => Ok(views.html.instance(i.instance))) getOrElse NotFound
+    instance.headOption map (i => Ok(views.html.instance(i.instance))) getOrElse NotFound(views.html.instanceNotFound(id))
   }
 
   def es(name: String) = AuthAction.async { implicit req =>

--- a/app/views/instanceNotFound.scala.html
+++ b/app/views/instanceNotFound.scala.html
@@ -1,0 +1,14 @@
+@(instanceId: String)(implicit request: play.api.mvc.Security.AuthenticatedRequest[_, com.gu.googleauth.UserIdentity])
+
+@main(s"Instance $instanceId not found", refreshSecs = Some(15)) {
+
+    <div class="container instance-info">
+        <div class="page-header">
+            <h1>Instance @instanceId not found</h1>
+        </div>
+
+        <div class="alert alert-warning">
+            No matching instance was found. It may have been terminated.
+        </div>
+    </div>
+}


### PR DESCRIPTION
We now see an "instance not found" message instead of a blank screen,
when attempting to view the details for an instance that is not in the
AWS account.
