### PR TITLE
Reduce aws api load

### DIFF
--- a/app/lib/SpreadingScheduledAgent.scala
+++ b/app/lib/SpreadingScheduledAgent.scala
@@ -1,0 +1,58 @@
+package lib
+
+import akka.actor.ActorSystem
+import akka.agent.Agent
+import play.api.Logger
+import play.api.libs.concurrent.Akka
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Success, Failure}
+
+object SpreadingScheduledAgent {
+  import play.api.Play.current
+
+  implicit val system = Akka.system
+
+  def apply[T](initialDelay: FiniteDuration, frequency: FiniteDuration, initialValue: T)(block: => Future[List[() => Future[T => T]]]): SpreadingScheduledAgent[T] = {
+    new SpreadingScheduledAgent(initialDelay, frequency, initialValue, block, system)
+  }
+}
+
+class SpreadingScheduledAgent[T](initialDelay: FiniteDuration, frequency: FiniteDuration, initialValue: T,
+  block: => Future[List[() => Future[T => T]]], system: ActorSystem
+)(implicit ec: ExecutionContext) {
+
+  val agent = Agent[T](initialValue)
+
+  val log = Logger[SpreadingScheduledAgent[T]](classOf[SpreadingScheduledAgent[T]])
+
+  private def delayedUpdate(delay: FiniteDuration, update: () => Future[T => T]) = {
+    system.scheduler.scheduleOnce(delay) {
+      update().onComplete {
+        case Success(result) => agent send result
+        case Failure(e) => Logger.warn("scheduling agent part failure", e)
+      }
+    }
+  }
+
+  val agentSchedule = system.scheduler.schedule(initialDelay, frequency) {
+    block.onComplete {
+      case Success(result) =>
+        result.zipWithIndex foreach { case (update, index) =>
+          delayedUpdate(index * frequency / result.length, update)
+        }
+      case Failure(e) => Logger.warn("scheduled agent failed", e)
+    }
+  }
+
+  def get(): T = agent()
+
+  def apply(): T = get()
+
+  def shutdown() {
+    agentSchedule.cancel()
+  }
+
+}

--- a/app/model/ASG.scala
+++ b/app/model/ASG.scala
@@ -17,10 +17,20 @@ import com.amazonaws.services.cloudwatch.model.Statistic._
 import org.joda.time.DateTime
 import play.api.libs.json.JsObject
 
-case class ASG(name: String, stage: Option[String], app: Option[String], stack: Option[String],
-                 elb: Option[ELB], members: Seq[ASGMember], recentActivity: Seq[ScalingAction],
-                 cpu: Seq[Datapoint],suspendedActivities: Seq[String], approxMonthlyCost: Option[BigDecimal],
-                 moreDetailsLink: Option[String])
+case class ASG(
+  arn: String,
+  lastUpdated: DateTime,
+  name: String,
+  stage: Option[String],
+  app: Option[String],
+  stack: Option[String],
+  elb: Option[ELB],
+  members: Seq[ASGMember],
+  recentActivity: Seq[ScalingAction],
+  cpu: Seq[Datapoint],
+  suspendedActivities: Seq[String],
+  approxMonthlyCost: Option[BigDecimal],
+  moreDetailsLink: Option[String])
 
 object ASG {
   val log = Logger[ASG](classOf[ASG])
@@ -64,6 +74,8 @@ object ASG {
         if (t.format == Some("elasticsearch")) Some(routes.Application.es(name).url) else None
       }
       ASG(
+        asg.getAutoScalingGroupARN,
+        DateTime.now,
         name, tags.get("Stage"), tags.get("App") orElse tags.get("Role"), tags.get("Stack"),
         lb, members.sortBy(_.instance.availabilityZone), activities, cpu, asg.getSuspendedProcesses.toList.map(_.getProcessName).sorted,
         Try(members.flatMap(_.instance.approxMonthlyCost).sum).toOption, moreDetailsLink

--- a/app/model/ASG.scala
+++ b/app/model/ASG.scala
@@ -36,49 +36,35 @@ object ASG {
   val log = Logger[ASG](classOf[ASG])
 
   def from(asg: AutoScalingGroup)(implicit conn: AmazonConnection): Future[ASG] =  {
-    import play.api.Play.current
     log.debug(s"Retrieving details for ${asg.getAutoScalingGroupName}")
-    val elb = FutureOption((asg.getLoadBalancerNames.headOption map (ELB.forName(_))))
 
-    val recentActivity = for {
-      actions <- ScalingAction.forGroup(asg.getAutoScalingGroupName)
-    } yield actions filter (_.isRecent)
+    val futElb = FutureOption(asg.getLoadBalancerNames.headOption map ELB.forName)
+    val futActivities = recentActivity(asg)
+    val futAsgStats = cpuStats(asg)
 
-    val clusterMembers = for {
-      lb <- elb
-      members <- Future.sequence(asg.getInstances map { m =>
-        val membersOfElb = lb.map(_.members).getOrElse(Nil)
-        for {
-          i <- Instance.get(m.getInstanceId)
-        } yield ASGMember.from(m, membersOfElb.find(_.id == m.getInstanceId), i)
-      })
-    } yield members
-
-    val stats = AWS.futureOf(conn.cloudWatch.getMetricStatisticsAsync, new GetMetricStatisticsRequest()
-      .withDimensions(new Dimension().withName("AutoScalingGroupName").withValue(asg.getAutoScalingGroupName))
-      .withMetricName("CPUUtilization").withNamespace("AWS/EC2").withPeriod(60)
-      .withStatistics(Maximum, Average)
-      .withStartTime(DateTime.now().minusHours(3).toDate).withEndTime(DateTime.now().toDate)
-    )
+    val name = asg.getAutoScalingGroupName
+    val tags = asg.getTags.map(t => t.getKey -> t.getValue).toMap
 
     for {
-      lb <- elb
-      activities <- recentActivity
-      members <- clusterMembers
-      asgStats <- stats
+      elb <- futElb
+      activities <- futActivities
+      asgStats <- futAsgStats
     } yield {
-      val cpu = asgStats.getDatapoints.sortBy(_.getTimestamp)
-      val tags = asg.getTags.map(t => t.getKey -> t.getValue).toMap
-      val name = asg.getAutoScalingGroupName
-      val moreDetailsLink = ManagementTag(tags.get("Management")).flatMap { t =>
-        if (t.format == Some("elasticsearch")) Some(routes.Application.es(name).url) else None
-      }
+      val members = clusterMembers(asg, elb.map(_.members).getOrElse(Nil))
       ASG(
-        asg.getAutoScalingGroupARN,
-        DateTime.now,
-        name, tags.get("Stage"), tags.get("App") orElse tags.get("Role"), tags.get("Stack"),
-        lb, members.sortBy(_.instance.availabilityZone), activities, cpu, asg.getSuspendedProcesses.toList.map(_.getProcessName).sorted,
-        Try(members.flatMap(_.instance.approxMonthlyCost).sum).toOption, moreDetailsLink
+        arn = asg.getAutoScalingGroupARN,
+        lastUpdated = DateTime.now,
+        name = name,
+        stage = tags.get("Stage"),
+        app = tags.get("App") orElse tags.get("Role"),
+        stack = tags.get("Stack"),
+        elb = elb,
+        members = members.sortBy(_.instance.availabilityZone),
+        recentActivity = activities,
+        cpu = asgStats.getDatapoints.sortBy(_.getTimestamp),
+        suspendedActivities = asg.getSuspendedProcesses.toList.map(_.getProcessName).sorted,
+        approxMonthlyCost = Try(members.flatMap(_.instance.approxMonthlyCost).sum).toOption,
+        moreDetailsLink = moreDetailsLink(name, tags)
       )
     }
   }
@@ -86,6 +72,32 @@ object ASG {
   import AWS.Writes._
 
   implicit val writes = Json.writes[ASG]
+
+  private def clusterMembers(asg: AutoScalingGroup, membersOfElb: List[ELBMember]) = for {
+    asgInstance <- asg.getInstances
+    instance <- Instances.getById(asgInstance.getInstanceId)
+  } yield ASGMember.from(asgInstance, membersOfElb.find(_.id == asgInstance.getInstanceId), instance)
+
+  private def cpuStats(asg: AutoScalingGroup)(implicit conn: AmazonConnection) = {
+    AWS.futureOf(conn.cloudWatch.getMetricStatisticsAsync, new GetMetricStatisticsRequest()
+      .withDimensions(new Dimension().withName("AutoScalingGroupName").withValue(asg.getAutoScalingGroupName))
+      .withMetricName("CPUUtilization").withNamespace("AWS/EC2").withPeriod(60)
+      .withStatistics(Maximum, Average)
+      .withStartTime(DateTime.now().minusHours(3).toDate).withEndTime(DateTime.now().toDate)
+    )
+  }
+
+  private def recentActivity(asg: AutoScalingGroup)(implicit conn: AmazonConnection) =
+    ScalingAction.forGroup(asg.getAutoScalingGroupName) map { _.filter(_.isRecent) }
+
+  private def moreDetailsLink(name: String, tags: Map[String, String]) = {
+    ManagementTag(tags.get("Management")) flatMap { t =>
+      if (t.format.contains("elasticsearch"))
+        Some(routes.Application.es(name).url)
+      else
+        None
+    }
+  }
 }
 
 object FutureOption {

--- a/app/model/Instances.scala
+++ b/app/model/Instances.scala
@@ -1,0 +1,46 @@
+package model
+
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.ec2.model.{Instance => AwsInstance, DescribeInstancesResult, DescribeInstancesRequest}
+import lib.{ScheduledAgent, AWS, AmazonConnection}
+import play.api.Logger
+import collection.JavaConversions._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object Instances {
+
+  private val log = Logger[Instance](classOf[Instance])
+
+  private val agent = ScheduledAgent[Seq[Instance]](0.seconds, 1.minute, Seq.empty) {
+    def describeInstanceRequest(nextToken: Option[String]) =
+      nextToken map { new DescribeInstancesRequest().withNextToken } getOrElse { new DescribeInstancesRequest() }
+
+    def withAwsInstances[T](token: Option[String] = None)(fn: AwsInstance => T): Future[Seq[T]] = {
+      AWS.futureOf(AWS.connection.ec2.describeInstancesAsync, describeInstanceRequest(token)) flatMap { result =>
+        val nextToken = Option(result.getNextToken)
+        if (nextToken.isDefined)
+          withAwsInstances(nextToken)(fn)
+        else
+          Future.successful(result.getReservations.flatMap(_.getInstances).map(fn))
+      } recover {
+        case e =>
+          log.error(s"Unable to retrieve all instances", e)
+          Seq.empty
+      }
+    }
+
+    val instances = withAwsInstances() { instance =>
+      Instance.from(instance) recover {
+        case _ => UnknownInstance(instance.getInstanceId)
+      }
+    }
+    instances.flatMap(Future.sequence(_))
+  }
+
+  def apply(): Seq[Instance] = agent.get()
+
+  def getById(id: String): Option[Instance] = agent.get().find(_.id == id)
+}

--- a/app/model/Queue.scala
+++ b/app/model/Queue.scala
@@ -8,7 +8,7 @@ import org.joda.time.DateTime
 import collection.convert.wrapAsScala._
 import play.api.Logger
 
-case class Queue(name: String, url: String, approxQueueLength: Seq[Datapoint])
+case class Queue(lastUpdated: DateTime, name: String, url: String, approxQueueLength: Seq[Datapoint])
 
 object Queue {
   def from(url: String)(implicit conn: AmazonConnection, context: ExecutionContext): Future[Queue] = {
@@ -19,6 +19,6 @@ object Queue {
         .withMetricName("ApproximateNumberOfMessagesVisible").withNamespace("AWS/SQS").withPeriod(60).withStatistics("Average")
         .withStartTime(DateTime.now().minusHours(3).toDate).withEndTime(DateTime.now().toDate)
       )
-    } yield Queue(name, url, stats.getDatapoints.sortBy(_.getTimestamp))
+    } yield Queue(DateTime.now, name, url, stats.getDatapoints.sortBy(_.getTimestamp))
   }
 }

--- a/test/model/EstateTest.scala
+++ b/test/model/EstateTest.scala
@@ -40,6 +40,7 @@ class EstateTest extends Specification {
   }
 
   def asg(stage: String, stack: Option[String] = None, numMembers: Int = 1) = ASG(
+    "arn:test", DateTime.now,
     s"name-${Random.alphanumeric}", Some(stage), None, stack, None,
       Seq.fill(numMembers)(ASGMember(Random.alphanumeric.toString(), None, "", None, None, "", "", null)), Nil, Nil, Nil, None, None
   )


### PR DESCRIPTION
- Spread out ASG data refreshes over the update interval so that we don't request everything at 0s
- Get all EC2 instances in a single request rather than one at a time
