### PR TITLE
Filter out tags marked for termination when grouping instances

### DIFF
--- a/app/model/ASG.scala
+++ b/app/model/ASG.scala
@@ -23,7 +23,9 @@ case class ASG(name: Option[String], stage: Option[String], app: Option[String],
 object ASG {
   val log = Logger[ASG](classOf[ASG])
 
-  def fromApp(tags: Map[String, String], instances: List[com.amazonaws.services.ec2.model.Instance])(implicit conn: AmazonConnection): Future[ASG] = {
+  def fromApp(instances: List[com.amazonaws.services.ec2.model.Instance])(implicit conn: AmazonConnection): Future[ASG] = {
+    val tags = instances.flatMap(i => i.getTags.toList.map(t => t.getKey -> t.getValue)).toMap
+
     val autoScalingGroupNameOpt = tags.get("aws:autoscaling:groupName")
 
     val asgFtO = for {

--- a/app/model/Estate.scala
+++ b/app/model/Estate.scala
@@ -96,8 +96,8 @@ object Estate {
 
   def groupInstancesByTag(instances: List[AwsEc2Instance]): Map[Map[String, String], List[AwsEc2Instance]] = {
     instances.groupBy(i => {
-      i.getTags.filterNot(t => t.getKey == "Magenta" && t.getValue == "Terminate")
-               .map(t => t.getKey -> t.getValue).toMap
+      i.getTags.toList.filter(t => t.getKey == "App" || t.getKey == "Stage" || t.getKey == "Stack")
+        .map(t => t.getKey -> t.getValue).toMap
     })
   }
 
@@ -108,7 +108,7 @@ object Estate {
     for {
       instances <- instancesFuture
       tagsToInstances = groupInstancesByTag(instances)
-      asgs <- Future.traverse(tagsToInstances)({case(tagsMap, instances) => ASG.fromApp(tagsMap, instances)})
+      asgs <- Future.traverse(tagsToInstances)({case(_, instances) => ASG.fromApp(instances)})
       queueResult <- queuesFuture.recover {
         case NonFatal(e) => {
           log.logger.error("Error retrieving queues", e)

--- a/test/model/EstateTest.scala
+++ b/test/model/EstateTest.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.amazonaws.services.ec2.model.{Tag, Instance => AwsEc2Instance}
 import org.specs2.mutable._
 import com.amazonaws.services.autoscaling.model.{TagDescription, AutoScalingGroup}
 import collection.convert.wrapAll._


### PR DESCRIPTION
So that in a deploy phase we group together instances marked for termination with the new instances in that group.

cc @philwills - you might not like this implementation since it leaks a bit of logic from riffraff into the code base. Could also be a sign that grouping instances by 'tags'  isn't quite what we want to do with instances. An alternative could be a to group by specific tags such as stage and app, but it relies on instances being tagged in that way.

