### PR TITLE
add endpoint to display estimated costs in json

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,13 +1,17 @@
 package controllers
 
+import com.amazonaws.services.cloudwatch.model.Statistic._
+import lib.AWS
+import org.joda.time.DateTime
 import play.api.mvc._
 import model._
 import java.text.DecimalFormat
 import play.api.libs.json.{JsString, Json, Writes}
-import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.{Dimension, GetMetricStatisticsRequest, GetMetricStatisticsResult, Datapoint}
 import scala.util.Random
 import play.api.libs.ws.WS
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object Application extends Controller with AuthActions {
 
@@ -82,5 +86,11 @@ object Application extends Controller with AuthActions {
         |User-agent: *
         |Disallow: *
       """.stripMargin)
+  }
+
+  def billEstimates() = Action.async { req =>
+    for {
+      billEst <- Billing.billEstimatesByService
+    }yield Ok(Json.toJson(ServiceToCost.fromBillEst(billEst)))
   }
 }

--- a/app/lib/AmazonConnection.scala
+++ b/app/lib/AmazonConnection.scala
@@ -27,6 +27,9 @@ class AmazonConnection(clientConfig: ClientConfiguration) {
   val s3 = new AmazonS3Client(credentialsProvider, clientConfig)
   val cloudWatch: AmazonCloudWatchAsyncClient = Region.getRegion(Regions.EU_WEST_1).createClient(
     classOf[AmazonCloudWatchAsyncClient], credentialsProvider, clientConfig)
+  //all billing data in is the US region
+  val billingWatch : AmazonCloudWatchAsyncClient = Region.getRegion(Regions.US_EAST_1).createClient(
+    classOf[AmazonCloudWatchAsyncClient], credentialsProvider, clientConfig)
   val sqs = Region.getRegion(Regions.EU_WEST_1).createClient(
     classOf[AmazonSQSAsyncClient], credentialsProvider, clientConfig)
   val dynamo = Region.getRegion(Regions.EU_WEST_1).createClient(

--- a/app/model/Billing.scala
+++ b/app/model/Billing.scala
@@ -1,0 +1,59 @@
+package model
+
+import com.amazonaws.services.cloudwatch.model.Statistic._
+import com.amazonaws.services.cloudwatch.model.{Datapoint, Dimension, GetMetricStatisticsRequest, GetMetricStatisticsResult}
+import lib.AWS
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import scala.concurrent.ExecutionContext.Implicits.global
+import collection.JavaConversions._
+
+import scala.concurrent.Future
+
+object Billing {
+
+  val services = List("AmazonS3", "AmazonEC2", "ElasticMapReduce", "all")
+
+  def last24hrCostByService(service: String):Future[GetMetricStatisticsResult] = {
+    implicit val conn = AWS.connection
+    val metricReq =  new GetMetricStatisticsRequest()
+      .withMetricName("EstimatedCharges").withNamespace("AWS/Billing").withPeriod(24 * 60 * 60)
+      .withDimensions(new Dimension().withName("Currency").withValue("USD"))
+      .withStatistics(Maximum)
+      .withStartTime(DateTime.now().minusHours(60).toDate).withEndTime(DateTime.now().toDate)
+    val withService = if(service=="all") metricReq else metricReq.withDimensions(new Dimension().withName("ServiceName").withValue(service))
+    AWS.futureOf(conn.billingWatch.getMetricStatisticsAsync, withService)
+  }
+
+  def parseBillingData(res: GetMetricStatisticsResult, service: String): Option[BillEstimate] = {
+    val datapoints = res.getDatapoints.sortBy(_.getTimestamp).toList
+    (for {
+      first <- datapoints.headOption
+      second <- datapoints.drop(1).headOption
+      cost =  second.getMaximum() - first.getMaximum()
+    } yield (BillEstimate(first.getTimestamp().toString, second.getTimestamp().toString, service, cost)))
+  }
+
+  def billEstimatesByService: Future[List[BillEstimate]] = {
+    Future.sequence {
+      services.map(s =>
+        last24hrCostByService(s).map(res => parseBillingData(res,s))
+      )
+    }.map(_.flatten)
+  }
+}
+
+case class BillEstimate(from: String, to: String, service: String, cost: Double)
+
+case class ServiceToCost(from: String, to: String, cost: Map[String, Double])
+
+object ServiceToCost {
+
+  implicit val jsonFormat = Json.format[ServiceToCost]
+
+  def fromBillEst(billEst: List[BillEstimate]): List[ServiceToCost] = {
+    billEst.groupBy(b => (b.from, b.to)).map { case ((from, to), bills) =>
+      ServiceToCost(from, to, bills.map(b => b.service -> b.cost).toMap)
+    }.toList
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,7 @@ GET        /queues                        controllers.Application.queues
 GET        /$stage<.*?>.json              controllers.Application.stageJson(stage)
 GET        /:stage                        controllers.Application.stage(stage)
 
+GET        /api/billEstimates             controllers.Application.billEstimates
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file                  controllers.Assets.at(path="/public", file)
 


### PR DESCRIPTION
@philwills - I'm not sure if you will agree if this is the right place for this, but this adds an endpoint to expose estimated daily costs in AWS, which we will poll using logstash and graph using Kibana. Alternatively, I can make a separate API service for this kind of thing, but I thought it was general enough to belong here.

Please let me know your thoughts.
