### PR TITLE
Update to  sbt-riffraff-artifact 0.9.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.4")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.1")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.4")
 


### PR DESCRIPTION
This is in the new format without the need to zip things up, speeding up builds/deploys and allowing for faster previews.