### PR TITLE
increase the number of characters displayed for instance ids

### DIFF
--- a/app/model/ASGMember.scala
+++ b/app/model/ASGMember.scala
@@ -27,7 +27,7 @@ object ASGMember {
       case _ => "danger"
     }
 
-    val truncatedId: String = Ascii.truncate(instance.id, 8, "...")
+    val truncatedId: String = Ascii.truncate(instance.id, 9, "…")
 
     ASGMember(instance.id, truncatedId, description, instance.uptime, instance.version, lbState, lifecycleState, goodorbad, instance)
   }


### PR DESCRIPTION
Previously too few characters were being displayed in the truncated instance ids. Here we use the single character ellipsis rather than three .s to increase the number of meaningful characters our truncate expression resolves to.

