### PR TITLE
fix status app to show apps which have multiple ASGs

### DIFF
--- a/app/model/Estate.scala
+++ b/app/model/Estate.scala
@@ -116,7 +116,7 @@ object Estate {
         }
       }
       queues <- Future.traverse(queueResult.getQueueUrls.toSeq)(Queue.from)
-    } yield PopulatedEstate(asgs.seq.toList, queues, DateTime.now)
+    } yield PopulatedEstate(asgs.seq.toList.flatten, queues, DateTime.now)
   }
   def apply() = estateAgent()
 }


### PR DESCRIPTION
<img width="1082" alt="asgs" src="https://user-images.githubusercontent.com/9820960/36606050-69caa014-18ba-11e8-93b1-5c37cc580230.png">

Now we have two ASGs for our elasticsearch app (see https://github.com/guardian/ophan/pull/2673), we would like to see the groups separated in the Status app to help us identify master and non-master nodes.

This change has the added benefit of displaying the AutoScaling and ELB information for both groups, information which is lost with multiple ASGs per app in the old world. 