### PR TITLE
Show EC2 instance 'Name', helpful for non-cattle servers...

### DIFF
--- a/app/model/Instance.scala
+++ b/app/model/Instance.scala
@@ -39,7 +39,9 @@ case class Instance(
   version: Option[String],
 
   usefulUrls: Map[String, String]
-)
+) {
+  val nameOpt = tags.get("Name")
+}
 
 object EC2Instance {
   def apply(awsInstance: AwsEc2Instance, version: Option[String], usefulUrls: Seq[(String, String)]) = {

--- a/app/views/instance.scala.html
+++ b/app/views/instance.scala.html
@@ -5,7 +5,11 @@
     <div class="container instance-info">
         <div class="page-header">
 
-            <h1>Instance Status for @instance.id</h1>
+            <h1>Instance Status for @instance.id
+            @for(name <- instance.nameOpt) {
+                (<a href="https://www.google.com/search?q=@name+wiki">@name</a>)
+            }
+            </h1>
         </div>
 
         <h2>General</h2>


### PR DESCRIPTION
Like long-lived Elasticsearch boxes https://github.com/guardian/ophan/pull/2677

The 'name' value is inserted into the instance headline like this:

![image](https://user-images.githubusercontent.com/52038/36797486-fa520058-1c9f-11e8-9bb9-69dcdb81a8ab.png)

Clicking on the link takes you to a google search for that name (for educational purposes :books: :boom:  )
