### PR TITLE
Update directions for running locally and add nginx setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Running locally
 
 ####Credentials
 
-Credentials are retrieved using from the configuration file used for the AWS CLI. For a Guardian stack, get your 
+Credentials are retrieved from the configuration file used for the AWS CLI. For a Guardian stack, get your 
 credentials via 'export to shell' in Janus as status-app doesn't currently handle AWS profiles.
 
 #### Nginx setup

--- a/README.md
+++ b/README.md
@@ -32,10 +32,42 @@ access to the management port of your apps.
 Running locally
 ---------------
 
+####Credentials
+
+Credentials are retrieved using from the configuration file used for the AWS CLI. For a Guardian stack, get your 
+credentials via 'export to shell' in Janus as status-app doesn't currently handle AWS profiles.
+
+#### Nginx setup
+
+You'll need to perform the Nginx setup for 
+[identity-platform](https://github.com/guardian/identity-platform/blob/master/nginx/README.md) 
+first, before you do anything else.
+
+##### Status-app specific setup
+Update your hosts file
+
+Add the following local development domain to your hosts file in /etc/hosts:
+
+`127.0.0.1   status.thegulocal.com`
+
+Run status-app's Nginx setup script
+Run the status-app setup.sh script from the root of the support-frontend project:
+
+`./nginx/setup.sh`
+
+The script doesn't start Nginx. To manually start it run `sudo nginx` or `sudo systemctl start nginx` depending on your system.
+
+#### Start the app
 If you just want to run it locally, it's a standard [Play 2](http://www.playframework.com/) 
 app and can be run with the 'run' command from an [SBT](http://www.scala-sbt.org/) prompt.
 
-Credentials are retrieved using from the configuration file used for the AWS CLI.
+`sbt run` 
+
+this defaults to port 9000
+
+visit 
+
+`https://status.thegulocal.com`
 
 Contributing
 ------------

--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -41,8 +41,8 @@ object Config {
 
   lazy val googleAuthConfig = {
     val oauthConfig = dynamoConfig("oauth")
-    val host = if (Play.mode == Mode.Dev) "localhost:9000" else oauthConfig("host").getS
-    val protocol = if (Play.mode == Mode.Dev) "http" else oauthConfig.get("protocol").map(_.getS).getOrElse("http")
+    val host = if (Play.mode == Mode.Dev) "status.thegulocal.com" else oauthConfig("host").getS
+    val protocol = if (Play.mode == Mode.Dev) "https" else oauthConfig.get("protocol").map(_.getS).getOrElse("http")
     GoogleAuthConfig(
       clientId = oauthConfig("clientId").getS,
       clientSecret = oauthConfig("clientSecret").getS,

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+
+echo "\n\nUsing NGINX_HOME=$NGINX_HOME"
+
+sudo mkdir -p $NGINX_HOME/sites-enabled
+sudo ln -fs $DIR/status.conf $NGINX_HOME/sites-enabled/status.conf

--- a/nginx/status.conf
+++ b/nginx/status.conf
@@ -1,0 +1,20 @@
+server {
+  listen 443;
+  server_name status.thegulocal.com;
+
+  ssl on;
+  ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+  ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+
+  ssl_session_timeout 5m;
+
+  ssl_protocols TLSv1;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+  ssl_prefer_server_ciphers on;
+
+  location / {
+    proxy_pass http://localhost:9000/;
+      proxy_set_header Host $http_host;
+  }
+}
+


### PR DESCRIPTION
I had some trouble getting status-app to run locally, so I have 

- updated the README
- added setup for NGINX. That way, we can set a callback url in the google developer console that will allow the app to run locally. 
