### PR TITLE
fix for regular healthcheck failures 

### DIFF
--- a/app/model/Estate.scala
+++ b/app/model/Estate.scala
@@ -68,9 +68,7 @@ case object PendingEstate extends Estate {
   def lastUpdated = None
 }
 
-class EstateProvider(
-  asgSource: ASGSource,
-)(implicit wsClient: WSClient, actorSystem: ActorSystem) {
+class EstateProvider(asgSource: ASGSource)(implicit wsClient: WSClient, actorSystem: ActorSystem) {
   val log = Logger(classOf[EstateProvider])
   implicit val conn = AWS.connection
   val estateAgent = ScheduledAgent[Estate](0.seconds, 30.seconds, PendingEstate) {

--- a/cloud-formation/status-app-secure.yaml
+++ b/cloud-formation/status-app-secure.yaml
@@ -17,7 +17,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.micro
+    Default: t2.small
     ConstraintDescription: must be a valid EC2 instance type.
   VPC:
     Description: ID of the VPC onto which to launch the application
@@ -154,7 +154,7 @@ Resources:
       SecurityGroups:
       - !Ref InstanceSecurityGroup
       AssociatePublicIpAddress: true
-      InstanceType: t2.micro
+      InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref StatusAppInstanceProfile
       UserData:
         Fn::Base64: !Sub |


### PR DESCRIPTION
The application gets terminated every day because of healthcheck failures.
Moving to play 2.6 made it much worse, making it fail every 1.5 hours ( or 2.5 if we use netty and disable akka http server). It looks like it was running out of cpu credits.
Using a t2.small rather than a t2.micro seems to solve the problem (its been running for over a day without problems).

Maybe there's optimisations that can be done for this to still run on a micro instance but that goes beyond the scope of the work to migrate to play 2.6

