### PR TITLE
fix branch names in riff raff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ javaOptions in Universal ++= Seq(
 serverLoading in Debian := Some(Systemd)
 riffRaffPackageType := (packageBin in Debian).value
 
-
+riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
+riffRaffManifestBranch := env("TRAVIS_BRANCH").getOrElse(git.gitCurrentBranch.value)
 riffRaffUploadArtifactBucket := Some("riffraff-artifact")
 riffRaffUploadManifestBucket := Some("riffraff-builds")
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 def branch(): Option[String] = {
   env("TRAVIS_PULL_REQUEST") match {
     case Some("false") => env("TRAVIS_BRANCH")
-    case _ => env("TRAVIS_PULL_REQUEST").map(pullRequestNumber => s"PullRequest#$pullRequestNumber")
+    case travisPR => travisPR.map(pullRequestNumber => s"PullRequest#$pullRequestNumber")
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 def branch(): Option[String] = {
   env("TRAVIS_PULL_REQUEST") match {
     case Some("false") => env("TRAVIS_BRANCH")
-    case travisPR => travisPR.map(pullRequestNumber => s"PullRequest#$pullRequestNumber")
+    case travisPR => travisPR.map(pullRequestNumber => s"pullRequest#$pullRequestNumber")
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,16 @@ serverLoading in Debian := Some(Systemd)
 riffRaffPackageType := (packageBin in Debian).value
 
 riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
-riffRaffManifestBranch := env("TRAVIS_BRANCH").getOrElse(git.gitCurrentBranch.value)
+
+def branch(): Option[String] = {
+  env("TRAVIS_PULL_REQUEST") match {
+    case Some("false") => env("TRAVIS_BRANCH")
+    case _ => env("TRAVIS_PULL_REQUEST")
+  }
+}
+
+riffRaffManifestBranch := branch().getOrElse(git.gitCurrentBranch.value)
+
 riffRaffUploadArtifactBucket := Some("riffraff-artifact")
 riffRaffUploadManifestBucket := Some("riffraff-builds")
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 def branch(): Option[String] = {
   env("TRAVIS_PULL_REQUEST") match {
     case Some("false") => env("TRAVIS_BRANCH")
-    case _ => env("TRAVIS_PULL_REQUEST")
+    case _ => env("TRAVIS_PULL_REQUEST").map(pullRequestNumber => s"PR #$pullRequestNumber")
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,18 +42,6 @@ javaOptions in Universal ++= Seq(
 )
 serverLoading in Debian := Some(Systemd)
 riffRaffPackageType := (packageBin in Debian).value
-
-riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
-
-def branch(): Option[String] = {
-  env("TRAVIS_PULL_REQUEST") match {
-    case Some("false") => env("TRAVIS_BRANCH")
-    case travisPR => travisPR.map(pullRequestNumber => s"pullRequest#$pullRequestNumber")
-  }
-}
-
-riffRaffManifestBranch := branch().getOrElse(git.gitCurrentBranch.value)
-
 riffRaffUploadArtifactBucket := Some("riffraff-artifact")
 riffRaffUploadManifestBucket := Some("riffraff-builds")
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 def branch(): Option[String] = {
   env("TRAVIS_PULL_REQUEST") match {
     case Some("false") => env("TRAVIS_BRANCH")
-    case _ => env("TRAVIS_PULL_REQUEST").map(pullRequestNumber => s"PR #$pullRequestNumber")
+    case _ => env("TRAVIS_PULL_REQUEST").map(pullRequestNumber => s"PullRequest#$pullRequestNumber")
   }
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.4")
 


### PR DESCRIPTION
added back build.sbt settings to provide the branch name to Riff Raff.

See build 449 of this branch vs previous builds in Riff Raff :

![barnchnames](https://user-images.githubusercontent.com/15324270/45684493-7465df80-bb3e-11e8-9027-92bc5756a42f.png)
