### PR TITLE
Update .prout.json

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,5 +1,5 @@
 {
   "checkpoints": {
-    "status.ophan.co.uk": { "url": "http://status.ophan.co.uk/management/manifest", "overdue": "1H" }
+    "status.ophan.co.uk": { "url": "https://status.ophan.co.uk/management/manifest", "overdue": "1H" }
   }
 }


### PR DESCRIPTION
it looks like the Ophan version of the status app is now https only, as a result merged PRs are always tagged pending ( for example the recent pr to fix branch names https://github.com/guardian/status-app/pull/72)