### PR TITLE
Add HSTS headers to the Status App so browsers use HTTPS all the time

### DIFF
--- a/app/filters/HSTSFilter.scala
+++ b/app/filters/HSTSFilter.scala
@@ -1,0 +1,12 @@
+package filters
+
+import play.api.http.HeaderNames.STRICT_TRANSPORT_SECURITY
+import play.api.mvc.{EssentialAction, EssentialFilter}
+
+import scala.concurrent.ExecutionContext
+
+class HSTSFilter(implicit ec: ExecutionContext) extends EssentialFilter {
+  def apply(next: EssentialAction) = EssentialAction { req =>
+    next(req).map(result => result.withHeaders(STRICT_TRANSPORT_SECURITY -> "max-age=31536000"))
+  }
+}

--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -2,6 +2,7 @@ package wiring
 
 import akka.actor.ActorSystem
 import controllers.{Login, Management, StatusAppAuthAction, routes, Application => ApplicationController}
+import filters.HSTSFilter
 import lib.DynamoConfig
 import model._
 import play.api.ApplicationLoader.Context
@@ -26,7 +27,7 @@ class MyComponents(context: Context)
     with AhcWSComponents
     with EhCacheComponents
     with controllers.AssetsComponents {
-  override def httpFilters: Seq[EssentialFilter] = Seq.empty
+  override def httpFilters: Seq[EssentialFilter] = Seq(new HSTSFilter)
 
   implicit val system: ActorSystem = actorSystem
   val dynamoConfig = new DynamoConfig(environment.mode, httpConfiguration)


### PR DESCRIPTION
[HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) is a way for sites to make sure that browsers *only* connect to them over https - so if a user enters simply `status.ophan.co.uk` the BROWSER will correct that to https://status.ophan.co.uk/ - rather than attempting to connect to http://status.ophan.co.uk/ (which just hangs indefinitely, our ELB's don't listen on HTTP port 80).

This follows on from https://github.com/guardian/play-googleauth/pull/68 - that didn't pass review because it doesn't highlight to developers what's happening - it was an attempt to sneak HSTS headers in through the back door!