### PR TITLE
Allow hourly re-authentication to happen without user-intervention

### DIFF
--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -39,7 +39,7 @@ class MyComponents(context: Context)
   val googleAuthConfig = dynamoConfig.googleAuthConfig
   val authAction = new StatusAppAuthAction[AnyContent](
     googleAuthConfig,
-    routes.Login.login(),
+    routes.Login.loginAction(),
     controllerComponents.parsers.default
   )(executionContext)
 


### PR DESCRIPTION
We noticed that we'd been having to re-authenticate with our Status App at https://status.ophan.co.uk/ more often - it was sending us to the _"Please click the button to login with your google account."_ page at https://status.ophan.co.uk/login many times during the course of the working day!

When Google handles authentication for us, it also passes back an `exp`
expiration field, indicating how long Google would like our Guardian
servers to treat this authorisation as valid before re-validating it with
them. I get the _impression_ that we seem to respect this more with the
Play 2.6 upgrade, but I haven't been able to dig out any actual evidence
of that.

Google currently sets the expiration time as 1 hour in the future,
so re-authentication happens hourly - whether the user has been active or
inactive. When this re-authentication happens, we *don't* need to force the
user to make any direct intervention - the re-authentication can take
place as a rapid invisible series of redirects to Google's servers (which
will check that the user is still logged in to their Google Account).

The `loginTarget` field on your instance of `AuthAction` controls where a
user with non-existent or expired credentials goes. As an example, on the
Ophan Dashboard at https://dashboard.ophan.co.uk we set this to
`routes.Login.loginAction()`, which immediately redirects the user off
on the invisible re-authentication journey - the ideal behaviour!

In the status-app, we were sending users instead to `routes.Login.login()`,
a human-visible page that requires clicking the `Login` button to continue-
which is why we were getting the intrusive re-authentication on an hourly
basis!

This change fixes the Status App to behave the same way as Ophan - we could
probably also update the scaladoc in `play-googleauth` to be clearer.