### PR TITLE
bump jackson-databind, jackson-annotations, jackson-core to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 scalaVersion := "2.12.6"
 scalacOptions ++= List("-feature", "-deprecation")
 
+val jacksonVersion = "2.9.7"
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.283",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",
@@ -23,7 +25,9 @@ libraryDependencies ++= Seq(
   "org.webjars" % "bootstrap" % "3.3.7",
   "org.webjars" % "d3js" % "3.5.17",
   "org.webjars" % "zeroclipboard" % "2.2.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
 )
 
 maintainer := "Phil Wills <philip.wills@theguardian.com>"


### PR DESCRIPTION
## Why are you doing this?
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested [here](https://github.com/aws/aws-sdk-java) that this shouldn't be a breaking change for the aws sdks, and indeed when I tested it by running the status-app locally, it wasn't. I bumped the versions and then just checked that the status page displayed the same before and after the version bump.

Any other suggested checks?
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com) // none. Inspired by Snyk.

## Changes

* Bumped jackson-databind, jackson-annotations, and jackson-core to 2.9.7