### PR TITLE
Bump jackson version and update SSL certificate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 scalaVersion := "2.12.6"
 scalacOptions ++= List("-feature", "-deprecation")
 
-val jacksonVersion = "2.9.7"
+val jacksonVersion = "2.9.8"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.283",

--- a/nginx/status.conf
+++ b/nginx/status.conf
@@ -3,8 +3,8 @@ server {
   server_name status.thegulocal.com;
 
   ssl on;
-  ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-  ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+  ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+  ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
   ssl_session_timeout 5m;
 


### PR DESCRIPTION
We need to upgrade Jacksonto `2.9.8` to patch up a vulnerability. This PR also updates the SSL certificate

This has been testsed locally on @lmath's machine. 