### PR TITLE
Update snyked dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % "0.7.7",
   "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
   "org.webjars.bower" % "react" % "0.13.3",
-  "org.webjars" % "bootstrap" % "3.3.7",
+  "org.webjars" % "bootstrap" % "3.4.1",
   "org.webjars" % "d3js" % "3.5.17",
   "org.webjars" % "zeroclipboard" % "2.2.0",
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersionBump,

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,10 @@ scalaVersion := "2.12.6"
 scalacOptions ++= List("-feature", "-deprecation")
 
 val jacksonVersion = "2.9.9"
+val jacksonVersionBump = "2.9.9.1"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.11.563",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.591",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",
   specs2 % Test,
   ehcache,
@@ -25,7 +26,7 @@ libraryDependencies ++= Seq(
   "org.webjars" % "bootstrap" % "3.3.7",
   "org.webjars" % "d3js" % "3.5.17",
   "org.webjars" % "zeroclipboard" % "2.2.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersionBump,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")


### PR DESCRIPTION
This PR updates some dependencies including ones that snyk has spotted.
See https://app.snyk.io/org/the-guardian-cuu/project/923895c3-3d65-4140-a01a-f1f5f1271fc0/ for the project view.
Interestinly we have somehow missed the bootstrap issue, there are multiple issues in the version we were using, including one https://app.snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-451162 that has been published for over a year! so I am not sure how we have systematically missed it the whole time
![image](https://user-images.githubusercontent.com/7304387/61467792-22ffca00-a974-11e9-9859-27cd6abc18a5.png)

I took the chance to update play, aws and sbt as it makes sense to keep them fresh while I'm in.

All tested locally and it seems to work, although it doesn't have all the VPC access needed to hit the instances directly.
