### PR TITLE
 Bumping to top of next version of Jackson Databind due to Snyk report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.12.10"
 scalacOptions ++= List("-feature", "-deprecation")
 
 val jacksonVersion = "2.9.10"
-val jacksonVersionBump = "2.9.10.4"
+val jacksonVersionBump = "2.9.10.5"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.591",

--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,10 @@ resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 scalaVersion := "2.12.10"
 scalacOptions ++= List("-feature", "-deprecation")
 
-val jacksonVersion = "2.9.10"
-val jacksonVersionBump = "2.9.10.5"
+val jacksonVersion = "2.10.5"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.11.591",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.827",
   "com.typesafe.akka" %% "akka-agent" % "2.5.16",
   specs2 % Test,
   ehcache,
@@ -26,9 +25,10 @@ libraryDependencies ++= Seq(
   "org.webjars" % "bootstrap" % "3.4.1",
   "org.webjars" % "d3js" % "3.5.17",
   "org.webjars" % "zeroclipboard" % "2.2.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersionBump,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
 )


### PR DESCRIPTION
## What does this change?
Bumping to top of next version of Jackson Databind (which we use in many other projects) for Snyk report: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-572316 and also the AWS SDK to the latest version.

I also updated the cbor dependency and have checked there are no others missing:

```
paul_brown ~/code/status-app (snyk-2020-07-28) $ sbt dependencyTree | grep jackson | grep -v "2.10"
[info]   | |   +-com.google.http-client:google-http-client-jackson2:1.20.0
paul_brown ~/code/status-app (snyk-2020-07-28) $
```
## How to test
Tested locally, seems to work fine.

## How can we measure success?
Snyk vulnerabilities go away after merging to master

## Have we considered potential risks?
Tested locally. This is an internal tool that's infrequently used and can be rolled back easily.

## Images
N/A