### PR TITLE
remove status-app from membership

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,6 +1,5 @@
 stacks:
 - ophan
-- membership
 deployments:
   ami:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
This PR stops status app deploying to membership.  I will also remove status app from the membership AWS account.

This means we don't have to keep paying for it and maintaining it!