### PR TITLE
Switch to ARM and fix Prout build-info

### DIFF
--- a/cloud-formation/status-app-secure.yaml
+++ b/cloud-formation/status-app-secure.yaml
@@ -17,7 +17,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.small
+    Default: t4g.small
     ConstraintDescription: must be a valid EC2 instance type.
   VPC:
     Description: ID of the VPC onto which to launch the application

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: status-app
     parameters:
       amiTags:
-        Recipe: ubuntu-xenial-status-app
+        Recipe: ophan-ubuntu-bionic-ARM
         AmigoStage: PROD
       amiParameter: ImageId
       amiEncrypted: true


### PR DESCRIPTION
ARM is cheaper and faster than Intel. We're going to use the Ophan [Ubuntu Amigo](https://amigo.gutools.co.uk/recipes/ophan-ubuntu-bionic-ARM) images for now - only the Ophan team is using the status app at the moment, so this feels reasonable.

Prout wasn't picking up recent PR changes - because the build info exposed in the manifest was based on Travis - and Status App is now built on TeamCity, rather than Travis.
