### PR TITLE
Updates the RiffRaff config to use the ophan-dist bucket

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,6 +12,8 @@ deployments:
       amiEncrypted: true
   status-app:
     type: autoscaling
+    parameters:
+      bucketSsmLookup: true
     dependencies: [ami]
 regions:
 - eu-west-1


### PR DESCRIPTION
## What does this change?

This PR aims to fix issues with the status-app RiffRaff deploy: 

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/4633246/182863415-e0e8c713-8ed0-44fd-b8bb-40b7e6c3b22b.png">

It updates the RiffRaff config to use the default param of `/account/services/artifact.bucket` which is set to `ophan-dist`.

I'm unclear why this started failing, it would be interesting to know.

## How to test

We can check the config is valid using the [RiffRaff tool](https://riffraff.gutools.co.uk/configuration/validation).

## How can we measure success?

We can deploy the status-app again!
