### PR TITLE
change Snyk organisation to ophan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,7 +11,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: guardian-capi
+      ORG: guardian-ophan
       SKIP_NODE: true
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Currently this repo is appearing under the `guardian-capi` snyk organisation, but we don't use the application.

After doing a bit of research it seems that only Ophan is still using it, so I would like to move it to your organisation, if that is OK with you!
