### PR TITLE
Migrate build pipeline from teamcity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: build
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'
+        java-version: '8'
+        cache: 'sbt'
+
+    - name: build steps
+      run: sbt clean test debian:packageBin
+
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: Status-App Tests
+        path: target/test-reports/*.xml
+        reporter: java-junit
+        only-summary: 'false'
+        fail-on-error: 'true'
+
+    - name: AWS Auth
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+        aws-region: eu-west-1
+
+    - name: Upload to riff-raff
+      uses: guardian/actions-riff-raff@v2
+      with:
+        configPath: riff-raff.yaml
+        projectName: status-app
+        buildNumberOffset: 180
+        contentDirectories: |
+          status-app:
+          - target/status-app_1.0_all.deb
+          - status-app.conf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
   workflow_dispatch:
   


### PR DESCRIPTION
## What does this change?

Moves the build pipeline to GitHub actions, as we look to deprecate TeamCity.
Deprecates the use of sbt plugin riffRaffUpload as well
