### PR TITLE
Opt-out of backups for status-app config DynamoDB table

### DIFF
--- a/cloud-formation/status-app-secure.yaml
+++ b/cloud-formation/status-app-secure.yaml
@@ -207,7 +207,7 @@ Resources:
         ReadCapacityUnits: '1'
         WriteCapacityUnits: '1'
       Tags:
-        # TODO - add opt-out reason here
+        # We are opting out of backups for this table because we believe it to be non-critical
         - Key: devx-backup-enabled
           Value: false
   MainDnsEntry:

--- a/cloud-formation/status-app-secure.yaml
+++ b/cloud-formation/status-app-secure.yaml
@@ -206,6 +206,10 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: '1'
         WriteCapacityUnits: '1'
+      Tags:
+        # TODO - add opt-out reason here
+        - Key: devx-backup-enabled
+          Value: false
   MainDnsEntry:
     Type: 'AWS::Route53::RecordSet'
     Condition: HasDNS


### PR DESCRIPTION
## What does this change?

This PR explicitly opts-out of backups for this DynamoDB table, based on this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588&range=F341). There is more detail on this project (and opting-out) [here](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.ikcdq5hb5oj5).

## How to test

I don't think this project has a `CODE` environment so I will deploy this to `PROD` (via the AWS Console) once it has been reviewed.

## How can we measure success?

This opt-out tagging helps DevX to audit our DynamoDB estate more easily (it allows us to differentiate between tables which definitely don't need backups and tables which have been forgotten/not reviewed).

## Have we considered potential risks?

The deployment of this change relies on a manual CFN update and should be applied carefully. Other than this, I don't think there are particular risks associated with this PR.