### PR TITLE
Drop port 22 access to status app instances

### DIFF
--- a/cloud-formation/status-app-secure.yaml
+++ b/cloud-formation/status-app-secure.yaml
@@ -189,10 +189,6 @@ Resources:
         FromPort: 9000
         ToPort: 9000
         SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: !Ref 'AllowedIngressIps'
   ConfigTable:
     Type: 'AWS::DynamoDB::Table'
     Properties:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Drop port 22 access to status app instances in light of https://blog.qualys.com/vulnerabilities-threat-research/2024/07/01/regresshion-remote-unauthenticated-code-execution-vulnerability-in-openssh-server

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Hard to test but Status-App is low priority.
