### PR TITLE
Bump AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ access to the management port of your apps.
 Running locally
 ---------------
 
-####Credentials
+#### Credentials
 
 Credentials are retrieved from the configuration file used for the AWS CLI. For a Guardian stack, get your 
 credentials via 'export to shell' in Janus as status-app doesn't currently handle AWS profiles.
@@ -42,7 +42,7 @@ credentials via 'export to shell' in Janus as status-app doesn't currently handl
 You'll need to do the [dev-nginx](https://github.com/guardian/dev-nginx) installation, before you do anything else.
 * In this repository's root directory, run:
 ```
-$ dev-nginx setup-app ./nginx/nginx-mapping.yml
+dev-nginx setup-app ./nginx/nginx-mapping.yml
 ```
 You will need to provide your sudo password.
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
-  "software.amazon.awssdk" % "ssm" % "2.29.24"
+  "software.amazon.awssdk" % "ssm" % "2.30.37"
 ) ++ Seq(
   "ec2", "elasticloadbalancing", "s3", "autoscaling", "cloudwatch", "sqs"
 ).map(artifact => "com.amazonaws" % s"aws-java-sdk-$artifact" % "1.12.694")


### PR DESCRIPTION
Bumps AWS SDK to 20.30.37, this brings in a later version of netty-handler, and resolves this [dependabot alert](https://github.com/guardian/status-app/security/dependabot/14)