### PR TITLE
Pin Netty to fix HTTP/2 and HTTP codec advisories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,24 @@ scalaVersion := "2.13.18"
 scalacOptions ++= List("-feature", "-deprecation")
 
 val jacksonVersion = "2.18.6"
+val nettyVersion = "4.1.132.Final"
+
+val nettyOverrides = Seq(
+  "netty-buffer",
+  "netty-codec",
+  "netty-codec-http",
+  "netty-codec-http2",
+  "netty-common",
+  "netty-handler",
+  "netty-resolver",
+  "netty-transport",
+  "netty-transport-classes-epoll",
+  "netty-transport-native-unix-common"
+).map("io.netty" % _ % nettyVersion)
 
 // Until all dependencies are on scala-java8-compat v1.x, this avoids unnecessary fatal eviction errors
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
+ThisBuild / dependencyOverrides ++= nettyOverrides
 
 libraryDependencies ++= Seq(
   specs2 % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -13,27 +13,15 @@ scalacOptions ++= List("-feature", "-deprecation")
 val jacksonVersion = "2.18.6"
 val nettyVersion = "4.1.132.Final"
 
-val nettyOverrides = Seq(
-  "netty-buffer",
-  "netty-codec",
-  "netty-codec-http",
-  "netty-codec-http2",
-  "netty-common",
-  "netty-handler",
-  "netty-resolver",
-  "netty-transport",
-  "netty-transport-classes-epoll",
-  "netty-transport-native-unix-common"
-).map("io.netty" % _ % nettyVersion)
-
 // Until all dependencies are on scala-java8-compat v1.x, this avoids unnecessary fatal eviction errors
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
-ThisBuild / dependencyOverrides ++= nettyOverrides
 
 libraryDependencies ++= Seq(
   specs2 % Test,
   ehcache,
   ws,
+  "io.netty" % "netty-codec-http" % nettyVersion,
+  "io.netty" % "netty-codec-http2" % nettyVersion,
   "com.gu.play-googleauth" %% "play-v30" % "6.0.0",
   "org.webjars.bower" % "react" % "0.14.0",
   "org.webjars" % "bootstrap" % "3.4.1",


### PR DESCRIPTION
## What does this change?
- pin Netty to `4.1.132.Final`
- add explicit `netty-codec-http` and `netty-codec-http2` dependencies instead of using `dependencyOverrides` following [Roberto's advice](https://github.com/guardian/maintaining-scala-projects/issues/20)

## Why?
This addresses:
- GHSA-pwqr-wmgm-9rr8
- GHSA-w9fj-cfpg-grvv

## Testing
- `sbt clean test debian:packageBin`
- `sbt dependencyTree | rg "io\.netty:(netty-codec-http|netty-codec-http2|netty-handler)"`
  - direct `4.1.132.Final` dependencies win normal eviction; older transitives are evicted